### PR TITLE
Fixed breakpoint setting

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -24,6 +24,7 @@
     },
     "devDependencies": {},
     "contributes": {
+        "breakpoints": [{ "language": "lua" }],
         "debuggers": [
             {
                 "type": "lua",


### PR DESCRIPTION
VS Code changed their extension settings. This change makes it once again possible to set breakpoints by adding the lua language to the breakpoints array.